### PR TITLE
Fixing some inconsistencies across different backends.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -70,6 +70,8 @@ elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
 endif ()
 option (DEBUG_SCHANNEL "Enable debug output in schannel backend" OFF)
 
+set_target_properties(https PROPERTIES PREFIX "")
+
 ### Dependencies
 target_link_libraries (https https-common)
 

--- a/src/common/HTTPRequest.cpp
+++ b/src/common/HTTPRequest.cpp
@@ -15,7 +15,7 @@ HTTPRequest::HTTPRequest(ConnectionFactory factory)
 HTTPSClient::Reply HTTPRequest::request(const HTTPSClient::Request &req)
 {
 	HTTPSClient::Reply reply;
-	reply.responseCode = 400;
+	reply.responseCode = 0;
 
 	auto info = parseUrl(req.url);
 	if (!info.valid)


### PR DESCRIPTION
Fixes #1 to match cURL backend, at least some parts of it. **None of these applies to NSURL backend as I don't have mac to test!**

The only notable difference is cURL backend returns 0 for invalid schema whilst the others returns nil followed by the error message.