### PR TITLE
Use SCH_CREDENTIALS in Windows 10 1809 or later.

### DIFF
--- a/src/windows/SChannelConnection.h
+++ b/src/windows/SChannelConnection.h
@@ -25,6 +25,8 @@ public:
 	static bool valid();
 
 private:
+	static bool useWindows11Codepath;
+
 	PlaintextConnection socket;
 	CtxtHandle *context;
 	std::vector<char> encRecvBuffer;
@@ -32,6 +34,9 @@ private:
 
 	size_t decrypt(char *buffer, size_t size, bool recurse = true);
 	void destroyContext();
+	bool acquire(void *credHandle);
+	bool acquireWindows11(void *credHandle);
+	bool acquireOldWindows(void *credHandle);
 };
 
 #endif // HTTPS_BACKEND_SCHANNEL


### PR DESCRIPTION
In Windows 11, `SCH_CREDENTIALS` must be used so it uses TLS 1.3.

TLS 1.3 can be tested with `https.request("https://crypto.cloudflare.com/cdn-cgi/trace")`.