### PR TITLE
Add WinINet Backend

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,6 +57,10 @@ add_library (https-android STATIC EXCLUDE_FROM_ALL
 	android/AndroidClient.cpp
 )
 
+add_library (https-wininet STATIC EXCLUDE_FROM_ALL
+	windows/WinINetClient.cpp
+)
+
 ### Flags
 if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
 	option (USE_CURL_BACKEND "Use the libcurl backend" ON)
@@ -64,6 +68,7 @@ if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
 	option (USE_SCHANNEL_BACKEND "Use the schannel backend (windows-only)" OFF)
 	option (USE_NSURL_BACKEND "Use the NSUrl backend (apple-only)" OFF)
 	option (USE_ANDROID_BACKEND "Use the Android Java backend (Android-only)" OFF)
+	option (USE_WININET_BACKEND "Use the WinINet backend (windows-only)" OFF)
 
 	option (USE_WINSOCK "Use winsock instead of BSD sockets (windows-only)" OFF)
 elseif (WIN32)
@@ -72,6 +77,7 @@ elseif (WIN32)
 	option (USE_SCHANNEL_BACKEND "Use the schannel backend (windows-only)" ON)
 	option (USE_NSURL_BACKEND "Use the NSUrl backend (apple-only)" OFF)
 	option (USE_ANDROID_BACKEND "Use the Android Java backend (Android-only)" OFF)
+	option (USE_WININET_BACKEND "Use the WinINet backend (windows-only)" ON)
 
 	option (USE_WINSOCK "Use winsock instead of BSD sockets (windows-only)" ON)
 
@@ -83,6 +89,7 @@ elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
 	option (USE_SCHANNEL_BACKEND "Use the schannel backend (windows-only)" OFF)
 	option (USE_NSURL_BACKEND "Use the NSUrl backend (apple-only)" ON)
 	option (USE_ANDROID_BACKEND "Use the Android Java backend (Android-only)" OFF)
+	option (USE_WININET_BACKEND "Use the WinINet backend (windows-only)" OFF)
 
 	option (USE_WINSOCK "Use winsock instead of BSD sockets (windows-only)" OFF)
 
@@ -98,6 +105,7 @@ elseif (ANDROID)
 	option (USE_SCHANNEL_BACKEND "Use the schannel backend (windows-only)" OFF)
 	option (USE_NSURL_BACKEND "Use the NSUrl backend (apple-only)" OFF)
 	option (USE_ANDROID_BACKEND "Use the Android Java backend (Android-only)" ON)
+	option (USE_WININET_BACKEND "Use the WinINet backend (windows-only)" OFF)
 
 	option (USE_WINSOCK "Use winsock instead of BSD sockets (windows-only)" OFF)
 
@@ -145,6 +153,11 @@ if (USE_ANDROID_BACKEND)
 	set(HTTPS_BACKEND_ANDROID ON)
 	target_link_libraries (https https-android)
 	message(STATUS "Ensure to add the Java files to your project too!")
+endif ()
+
+if (USE_WININET_BACKEND)
+	set(HTTPS_BACKEND_WININET ON)
+	target_link_libraries (https https-wininet wininet)
 endif ()
 
 if (USE_WINSOCK)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -77,7 +77,12 @@ elseif (WIN32)
 	option (USE_SCHANNEL_BACKEND "Use the schannel backend (windows-only)" ON)
 	option (USE_NSURL_BACKEND "Use the NSUrl backend (apple-only)" OFF)
 	option (USE_ANDROID_BACKEND "Use the Android Java backend (Android-only)" OFF)
-	option (USE_WININET_BACKEND "Use the WinINet backend (windows-only)" ON)
+
+	if (CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+		option (USE_WININET_BACKEND "Use the WinINet backend (windows-only)" OFF)
+	else ()
+		option (USE_WININET_BACKEND "Use the WinINet backend (windows-only)" ON)
+	endif ()
 
 	option (USE_WINSOCK "Use winsock instead of BSD sockets (windows-only)" ON)
 

--- a/src/common/HTTPRequest.h
+++ b/src/common/HTTPRequest.h
@@ -8,14 +8,6 @@
 class HTTPRequest
 {
 public:
-	typedef std::function<Connection *()> ConnectionFactory;
-	HTTPRequest(ConnectionFactory factory);
-
-	HTTPSClient::Reply request(const HTTPSClient::Request &req);
-
-private:
-	ConnectionFactory factory;
-
 	struct DissectedURL
 	{
 		bool valid;
@@ -25,6 +17,14 @@ private:
 		std::string query;
 		// TODO: Auth?
 	};
+	typedef std::function<Connection *()> ConnectionFactory;
 
-	DissectedURL parseUrl(const std::string &url);
+	HTTPRequest(ConnectionFactory factory);
+
+	HTTPSClient::Reply request(const HTTPSClient::Request &req);
+
+	static DissectedURL parseUrl(const std::string &url);
+
+private:
+	ConnectionFactory factory;
 };

--- a/src/common/HTTPS.cpp
+++ b/src/common/HTTPS.cpp
@@ -19,6 +19,9 @@
 #ifdef HTTPS_BACKEND_ANDROID
 #	include "../android/AndroidClient.h"
 #endif
+#ifdef HTTPS_BACKEND_WININET
+#	include "../windows/WinINetClient.h"
+#endif
 
 #ifdef HTTPS_BACKEND_CURL
 	static CurlClient curlclient;
@@ -35,6 +38,9 @@
 #ifdef HTTPS_BACKEND_ANDROID
 	static AndroidClient androidclient;
 #endif
+#ifdef HTTPS_BACKEND_WININET
+	static WinINetClient wininetclient;
+#endif
 
 static HTTPSClient *clients[] = {
 #ifdef HTTPS_BACKEND_CURL
@@ -42,6 +48,10 @@ static HTTPSClient *clients[] = {
 #endif
 #ifdef HTTPS_BACKEND_OPENSSL
 	&opensslclient,
+#endif
+	// WinINet must be above SChannel
+#ifdef HTTPS_BACKEND_WININET
+	&wininetclient,
 #endif
 #ifdef HTTPS_BACKEND_SCHANNEL
 	&schannelclient,

--- a/src/common/config-generated.h.in
+++ b/src/common/config-generated.h.in
@@ -3,5 +3,6 @@
 #cmakedefine HTTPS_BACKEND_SCHANNEL
 #cmakedefine HTTPS_BACKEND_NSURL
 #cmakedefine HTTPS_BACKEND_ANDROID
+#cmakedefine HTTPS_BACKEND_WININET
 #cmakedefine HTTPS_USE_WINSOCK
 #cmakedefine DEBUG_SCHANNEL

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -4,8 +4,12 @@
 	#include "common/config-generated.h"
 #elif defined(WIN32) || defined(_WIN32)
 	#define HTTPS_BACKEND_SCHANNEL
-	#define HTTPS_BACKEND_WININET
 	#define HTTPS_USE_WINSOCK
+	#include <winapifamily.h>
+	#if !defined(WINAPI_FAMILY) || (WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP)
+		// WinINet is only supported on desktop.
+		#define HTTPS_BACKEND_WININET
+	#endif
 #elif defined(__ANDROID__)
 	#define HTTPS_BACKEND_ANDROID
 #elif defined(__APPLE__)

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -4,6 +4,7 @@
 	#include "common/config-generated.h"
 #elif defined(WIN32) || defined(_WIN32)
 	#define HTTPS_BACKEND_SCHANNEL
+	#define HTTPS_BACKEND_WININET
 	#define HTTPS_USE_WINSOCK
 #elif defined(__ANDROID__)
 	#define HTTPS_BACKEND_ANDROID

--- a/src/windows/WinINetClient.cpp
+++ b/src/windows/WinINetClient.cpp
@@ -1,0 +1,222 @@
+#include "WinINetClient.h"
+
+#ifdef HTTPS_BACKEND_WININET
+
+#include <algorithm>
+#include <stdexcept>
+#include <sstream>
+#include <vector>
+
+#include <Windows.h>
+#include <wininet.h>
+
+#include "../common/HTTPRequest.h"
+
+class LazyHInternetLoader final
+{
+public:
+	LazyHInternetLoader(): hInternet(nullptr) { }
+	~LazyHInternetLoader()
+	{
+		if (hInternet)
+			InternetCloseHandle(hInternet);
+	}
+
+	HINTERNET getInstance()
+	{
+		if (!init)
+		{
+			hInternet = InternetOpenA("", INTERNET_OPEN_TYPE_PRECONFIG, nullptr, nullptr, 0);
+			if (hInternet)
+			{
+				// Try to enable HTTP2
+				DWORD httpProtocol = HTTP_PROTOCOL_FLAG_HTTP2;
+				InternetSetOptionA(hInternet, INTERNET_OPTION_ENABLE_HTTP_PROTOCOL, &httpProtocol, sizeof(DWORD));
+				SetLastError(0); // If it errors, ignore.
+			}
+		}
+
+		return hInternet;
+	}
+
+private:
+	bool init;
+	HINTERNET hInternet;
+};
+
+static thread_local LazyHInternetLoader hInternetCache;
+
+bool WinINetClient::valid() const
+{
+	// Allow disablement of WinINet backend.
+	const char *disabler = getenv("LUAHTTPS_DISABLE_WININET");
+	if (disabler && strcmp(disabler, "1") == 0)
+		return false;
+
+	return hInternetCache.getInstance() != nullptr;
+}
+
+HTTPSClient::Reply WinINetClient::request(const HTTPSClient::Request &req)
+{
+	Reply reply;
+	reply.responseCode = 0;
+
+	// Parse URL
+	auto parsedUrl = HTTPRequest::parseUrl(req.url);
+
+	// Default flags
+	DWORD inetFlags =
+		INTERNET_FLAG_NO_AUTH |
+		INTERNET_FLAG_NO_CACHE_WRITE |
+		INTERNET_FLAG_NO_COOKIES |
+		INTERNET_FLAG_NO_UI;
+
+	if (parsedUrl.schema == "https")
+		inetFlags |= INTERNET_FLAG_SECURE;
+	else if (parsedUrl.schema != "http")
+		return reply;
+
+	// Keep-Alive
+	auto connectHeader = req.headers.find("Connection");
+	auto headerEnd = req.headers.end();
+	if ((connectHeader != headerEnd && connectHeader->second != "close") || connectHeader == headerEnd)
+		inetFlags |= INTERNET_FLAG_KEEP_CONNECTION;
+
+	// Open internet
+	HINTERNET hInternet = hInternetCache.getInstance();
+	if (hInternet == nullptr)
+		return reply;
+
+	// Connect
+	HINTERNET hConnect = InternetConnectA(
+		hInternet,
+		parsedUrl.hostname.c_str(),
+		parsedUrl.port,
+		nullptr, nullptr,
+		INTERNET_SERVICE_HTTP,
+		INTERNET_FLAG_EXISTING_CONNECT,
+		(DWORD_PTR) this
+	);
+	if (!hConnect)
+		return reply;
+
+	std::string httpMethod = req.method;
+	std::transform(
+		httpMethod.begin(),
+		httpMethod.end(),
+		httpMethod.begin(),
+		[](char c) {return (char)toupper((unsigned char) c); }
+	);
+
+	// Open HTTP request
+	HINTERNET hHTTP = HttpOpenRequestA(
+		hConnect,
+		httpMethod.c_str(),
+		parsedUrl.query.c_str(),
+		nullptr,
+		nullptr,
+		nullptr,
+		inetFlags,
+		(DWORD_PTR) this
+	);
+	if (!hHTTP)
+	{
+		InternetCloseHandle(hConnect);
+		return reply;
+	}
+
+	// Send additional headers
+	HttpAddRequestHeadersA(hHTTP, "User-Agent:", 0, HTTP_ADDREQ_FLAG_REPLACE);
+	for (const auto &header: req.headers)
+	{
+		std::string headerString = header.first + ": " + header.second + "\r\n";
+		HttpAddRequestHeadersA(hHTTP, headerString.c_str(), headerString.length(), HTTP_ADDREQ_FLAG_ADD | HTTP_ADDREQ_FLAG_REPLACE);
+	}
+
+	// POST data
+	const char *postData = nullptr;
+	if (req.postdata.length() > 0 && (httpMethod != "GET" && httpMethod != "HEAD"))
+	{
+		char temp[48];
+		int len = sprintf(temp, "Content-Length: %u\r\n", (unsigned int) req.postdata.length());
+		postData = req.postdata.c_str();
+
+		HttpAddRequestHeadersA(hHTTP, temp, len, HTTP_ADDREQ_FLAG_ADD | HTTP_ADDREQ_FLAG_REPLACE);
+	}
+
+	// Send away!
+	BOOL result = HttpSendRequestA(hHTTP, nullptr, 0, (void *) postData, (DWORD) req.postdata.length());
+	if (!result)
+	{
+		InternetCloseHandle(hHTTP);
+		InternetCloseHandle(hConnect);
+		return reply;
+	}
+
+	DWORD bufferLength = sizeof(DWORD);
+	DWORD headerCounter = 0;
+
+	// Status code
+	DWORD statusCode = 0;
+	if (!HttpQueryInfoA(hHTTP, HTTP_QUERY_STATUS_CODE | HTTP_QUERY_FLAG_NUMBER, &statusCode, &bufferLength, &headerCounter))
+	{
+		InternetCloseHandle(hHTTP);
+		InternetCloseHandle(hConnect);
+		return reply;
+	}
+
+	// Query headers
+	std::vector<char> responseHeaders;
+	bufferLength = 0;
+	HttpQueryInfoA(hHTTP, HTTP_QUERY_RAW_HEADERS, responseHeaders.data(), &bufferLength, &headerCounter);
+	if (GetLastError() != ERROR_INSUFFICIENT_BUFFER)
+	{
+		InternetCloseHandle(hHTTP);
+		InternetCloseHandle(hConnect);
+		return reply;
+	}
+
+	responseHeaders.resize(bufferLength);
+	if (!HttpQueryInfoA(hHTTP, HTTP_QUERY_RAW_HEADERS, responseHeaders.data(), &bufferLength, &headerCounter))
+	{
+		InternetCloseHandle(hHTTP);
+		InternetCloseHandle(hConnect);
+		return reply;
+	}
+
+	for (const char *headerData = responseHeaders.data(); *headerData; headerData += strlen(headerData) + 1)
+	{
+		const char *value = strchr(headerData, ':');
+		if (value)
+		{
+			ptrdiff_t keyLen = (ptrdiff_t) (value - headerData);
+			reply.headers[std::string(headerData, keyLen)] = value + 2; // +2, colon and 1 space character.
+		}
+	}
+	responseHeaders.resize(1);
+
+	// Read response
+	std::stringstream responseData;
+	for (;;)
+	{
+		constexpr DWORD BUFFER_SIZE = 4096;
+		char buffer[BUFFER_SIZE];
+		DWORD readed = 0;
+
+		if (!InternetReadFile(hHTTP, buffer, BUFFER_SIZE, &readed))
+			break;
+
+		responseData.write(buffer, readed);
+		if (readed < BUFFER_SIZE)
+			break;
+	}
+
+	reply.body = responseData.str();
+	reply.responseCode = statusCode;
+
+	InternetCloseHandle(hHTTP);
+	InternetCloseHandle(hConnect);
+	return reply;
+}
+
+#endif // HTTPS_BACKEND_WININET

--- a/src/windows/WinINetClient.h
+++ b/src/windows/WinINetClient.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "../common/config.h"
+
+#ifdef HTTPS_BACKEND_WININET
+
+#include "../common/HTTPSClient.h"
+
+class WinINetClient: public HTTPSClient
+{
+public:
+	bool valid() const override;
+	HTTPSClient::Reply request(const HTTPSClient::Request &req) override;
+};
+
+#endif // HTTPS_BACKEND_WININET


### PR DESCRIPTION
In contrast to Schannel, WinINet is high-level API to perform HTTP and FTP request.

This pull request adds WinINet backend to lua-https. By using WinINet, all the TLS protocol and HTTP version selection is done automatically. For example, in Windows 10 1809 or later, it means WinINet will use TLS 1.3 and HTTP/2 when possible.

Note that WinINet backend is selected first (it's placed above Schannel backend), but this can be changed by setting environment variable `LUAHTTPS_DISABLE_WININET=1`. WinINet doesn't support UWP so it will be disabled in that case.