### PR TITLE
Fix operator precedence;

### DIFF
--- a/src/windows/SChannelConnection.cpp
+++ b/src/windows/SChannelConnection.cpp
@@ -248,12 +248,12 @@ bool SChannelConnection::connect(const std::string &hostname, uint16_t port)
 	{
 		SecPkgContext_Flags resultFlags;
 		QueryContextAttributes(context.get(), SECPKG_ATTR_FLAGS, &resultFlags);
-		if (resultFlags.Flags & ISC_REQ_CONFIDENTIALITY == 0)
+		if ((resultFlags.Flags & ISC_REQ_CONFIDENTIALITY) == 0)
 		{
 			debug << "Resulting context is not encrypted, marking as failed\n";
 			success = false;
 		}
-		if (resultFlags.Flags & ISC_REQ_INTEGRITY == 0)
+		if ((resultFlags.Flags & ISC_REQ_INTEGRITY) == 0)
 		{
 			debug << "Resulting context is not signed, marking as failed\n";
 			success = false;


### PR DESCRIPTION
Bitwise AND has lower precedence than equality.