### PR TITLE
[#27] Add support for building universal lua-https modules.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,18 +10,35 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Install Lua 5.1
-        uses: leafo/gh-actions-lua@v9.1.0
+      - name: Download LuaJIT
+        uses: actions/checkout@v3
         with:
-          luaVersion: "5.1.5"
+          repository: LuaJIT/LuaJIT
+          ref: v2.1
+          path: LuaJIT
+      - name: Compile universal LuaJIT
+        working-directory: ./LuaJIT
+        run: |
+          TARGET_FLAGS="-arch x86_64" make
+          cp ./src/libluajit.so ./src/libluajit_x64.dylib
+          cp ./src/luajit ./src/luajit_x64
+
+          make clean
+
+          TARGET_FLAGS="-arch arm64" make
+          cp ./src/libluajit.so ./src/libluajit_arm.dylib
+          cp ./src/luajit ./src/luajit_arm
+
+          lipo -create -output ./src/libluajit.dylib ./src/libluajit_x64.dylib ./src/libluajit_arm.dylib
+          lipo -create -output ./src/luajit ./src/luajit_x64 ./src/luajit_arm
       - name: Configure
-        run: cmake -Bbuild -S. -G Xcode -DLUA_INCLUDE_DIR=$PWD/.lua/include -DLUA_LIBRARIES=$PWD/.lua/lib/liblua.a
+        run: cmake -Bbuild -S. -G Xcode -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" -DLUA_INCLUDE_DIR=$PWD/LuaJIT/src -DLUA_LIBRARIES=$PWD/LuaJIT/src/lua
       - name: Build
         working-directory: build
         run: xcodebuild -configuration Release -scheme https
       - name: Test
         working-directory: ./build/src/Release
-        run: lua -l "https" ../../../example/test.lua
+        run: ../../../LuaJIT/src/luajit -l "https" ../../../example/test.lua
       - name: Artifact
         if: always()
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
# What
* Add support for building universal `lua-https` modules on macOS (see #27)

# How
* Since leafo's Github actions does not build universal LuaJIT modules, we have to build LuaJIT ourselves like done on Windows.

Attached is a sample LÖVE app using the produced artifact to fetch the LÖVE website and print the response to the screen. (The app extension is named weird because GitHub won't allow uploading a `.love` file but obviously will run fine in LÖVE for macOS).

[https.love.zip](https://github.com/love2d/lua-https/files/13999837/https.love.zip)

Result:

<img width="912" alt="Screenshot 2024-01-20 at 9 48 23 PM" src="https://github.com/love2d/lua-https/assets/1486068/9c875202-2102-4c50-9112-11ddd3e59f09">

