### PR TITLE
Add OpenSSL 3 support

### DIFF
--- a/src/generic/OpenSSLConnection.cpp
+++ b/src/generic/OpenSSLConnection.cpp
@@ -63,6 +63,7 @@ OpenSSLConnection::SSLFuncs::SSLFuncs()
 			LoadSymbol(SSLv23_method, sslhandle, "TLS_method"));
 
 	valid = valid && LoadSymbol(check_host, cryptohandle, "X509_check_host");
+	valid = valid && LoadSymbol(X509_free, cryptohandle, "X509_free");
 
 	if (library_init)
 		library_init();
@@ -125,6 +126,7 @@ bool OpenSSLConnection::connect(const std::string &hostname, uint16_t port)
 		close();
 		return false;
 	}
+	ssl.X509_free(cert);
 
 	return true;
 }

--- a/src/generic/OpenSSLConnection.cpp
+++ b/src/generic/OpenSSLConnection.cpp
@@ -39,8 +39,9 @@ OpenSSLConnection::SSLFuncs::SSLFuncs()
 		return;
 
 	valid = true;
-	valid = valid && (LoadSymbol(library_init, sslhandle, "SSL_library_init") ||
-			LoadSymbol(init_ssl, sslhandle, "OPENSSL_init_ssl"));
+	valid = valid && (
+			LoadSymbol(init_ssl, sslhandle, "OPENSSL_init_ssl") ||
+			LoadSymbol(library_init, sslhandle, "SSL_library_init"));
 
 	valid = valid && LoadSymbol(CTX_new, sslhandle, "SSL_CTX_new");
 	valid = valid && LoadSymbol(CTX_ctrl, sslhandle, "SSL_CTX_ctrl");
@@ -59,8 +60,10 @@ OpenSSLConnection::SSLFuncs::SSLFuncs()
 	valid = valid && (LoadSymbol(get_peer_certificate, sslhandle, "SSL_get1_peer_certificate") ||
 			LoadSymbol(get_peer_certificate, sslhandle, "SSL_get_peer_certificate"));
 
-	valid = valid && (LoadSymbol(SSLv23_method, sslhandle, "SSLv23_method") ||
-			LoadSymbol(SSLv23_method, sslhandle, "TLS_method"));
+	valid = valid && (
+			LoadSymbol(SSLv23_method, sslhandle, "TLS_client_method") ||
+			LoadSymbol(SSLv23_method, sslhandle, "TLS_method") ||
+			LoadSymbol(SSLv23_method, sslhandle, "SSLv23_method"));
 
 	valid = valid && LoadSymbol(check_host, cryptohandle, "X509_check_host");
 	valid = valid && LoadSymbol(X509_free, cryptohandle, "X509_free");

--- a/src/generic/OpenSSLConnection.cpp
+++ b/src/generic/OpenSSLConnection.cpp
@@ -45,6 +45,8 @@ OpenSSLConnection::SSLFuncs::SSLFuncs()
 
 	valid = valid && LoadSymbol(CTX_new, sslhandle, "SSL_CTX_new");
 	valid = valid && LoadSymbol(CTX_ctrl, sslhandle, "SSL_CTX_ctrl");
+	if (valid)
+		LoadSymbol(CTX_set_options, sslhandle, "SSL_CTX_set_options");
 	valid = valid && LoadSymbol(CTX_set_verify, sslhandle, "SSL_CTX_set_verify");
 	valid = valid && LoadSymbol(CTX_set_default_verify_paths, sslhandle, "SSL_CTX_set_default_verify_paths");
 	valid = valid && LoadSymbol(CTX_free, sslhandle, "SSL_CTX_free");
@@ -87,7 +89,10 @@ OpenSSLConnection::OpenSSLConnection()
 	if (!context)
 		return;
 
-	ssl.CTX_ctrl(context, SSL_CTRL_OPTIONS, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3, nullptr);
+	if (ssl.CTX_set_options)
+		ssl.CTX_set_options(context, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3);
+	else
+		ssl.CTX_ctrl(context, SSL_CTRL_OPTIONS, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3, nullptr);
 	ssl.CTX_set_verify(context, SSL_VERIFY_PEER, nullptr);
 	ssl.CTX_set_default_verify_paths(context);
 }

--- a/src/generic/OpenSSLConnection.cpp
+++ b/src/generic/OpenSSLConnection.cpp
@@ -13,9 +13,15 @@ OpenSSLConnection::SSLFuncs::SSLFuncs()
 
 	valid = false;
 
+	// Try OpenSSL 3
+	handle *sslhandle = OpenLibrary("libssl.so.3");
+	handle *cryptohandle = OpenLibrary("libcrypto.so.3");
 	// Try OpenSSL 1.1
-	handle *sslhandle = OpenLibrary("libssl.so.1.1");
-	handle *cryptohandle = OpenLibrary("libcrypto.so.1.1");
+	if (!sslhandle || !cryptohandle)
+	{
+		sslhandle = OpenLibrary("libssl.so.1.1");
+		cryptohandle = OpenLibrary("libcrypto.so.1.1");
+	}
 	// Try OpenSSL 1.0
 	if (!sslhandle || !cryptohandle)
 	{
@@ -50,7 +56,8 @@ OpenSSLConnection::SSLFuncs::SSLFuncs()
 	valid = valid && LoadSymbol(write, sslhandle, "SSL_write");
 	valid = valid && LoadSymbol(shutdown, sslhandle, "SSL_shutdown");
 	valid = valid && LoadSymbol(get_verify_result, sslhandle, "SSL_get_verify_result");
-	valid = valid && LoadSymbol(get_peer_certificate, sslhandle, "SSL_get_peer_certificate");
+	valid = valid && (LoadSymbol(get_peer_certificate, sslhandle, "SSL_get1_peer_certificate") ||
+			LoadSymbol(get_peer_certificate, sslhandle, "SSL_get_peer_certificate"));
 
 	valid = valid && (LoadSymbol(SSLv23_method, sslhandle, "SSLv23_method") ||
 			LoadSymbol(SSLv23_method, sslhandle, "TLS_method"));

--- a/src/generic/OpenSSLConnection.h
+++ b/src/generic/OpenSSLConnection.h
@@ -36,6 +36,7 @@ private:
 
 		SSL_CTX *(*CTX_new)(const SSL_METHOD *method);
 		long (*CTX_ctrl)(SSL_CTX *ctx, int cmd, long larg, void *parg);
+		long (*CTX_set_options)(SSL_CTX *ctx, long options);
 		void (*CTX_set_verify)(SSL_CTX *ctx, int mode, void *verify_callback);
 		int (*CTX_set_default_verify_paths)(SSL_CTX *ctx);
 		void (*CTX_free)(SSL_CTX *ctx);

--- a/src/generic/OpenSSLConnection.h
+++ b/src/generic/OpenSSLConnection.h
@@ -53,6 +53,7 @@ private:
 		const SSL_METHOD *(*SSLv23_method)();
 
 		int (*check_host)(X509 *cert, const char *name, size_t namelen, unsigned int flags, char **peername);
+		void (*X509_free)(X509* cert);
 	};
 	static SSLFuncs ssl;
 };


### PR DESCRIPTION
Fixes #21.
Based on the first commit of #30.

The only actual breakage was the rename of `SSL_get_peer_certificate` to `SSL_get1_peer_certificate`.

I had spotted a new HTTP client in OpenSSL3, and tried to get that to work.
Unfortunately, it's too limited for our purposes: it only supports GET and POST, and has no way to retrieve the status code or response headers.

