### PR TITLE
Fix Windows build with MSYS2/MinGW.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required (VERSION 3.13)
 
 ### Basic compilation settings
 set (CMAKE_POSITION_INDEPENDENT_CODE TRUE)
-set (CMAKE_CXX_STANDARD 11)
+set (CMAKE_CXX_STANDARD 14)
 
 include_directories (
 	${CMAKE_CURRENT_SOURCE_DIR}


### PR DESCRIPTION
`SChannelConnection` depends on a C++14 feature, `std::make_unique`. This is causing the build to fail on Windows when compiling with MSYS2/MinGW.

See example build failure with MSYS2/MinGW:

![image](https://github.com/love2d/lua-https/assets/1486068/c2be9956-52d9-4dd4-a5a5-7ce6744c3475)
