### PR TITLE
Enable ARC support for apple/NSURLClient.mm

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -116,6 +116,10 @@ elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
 	option (USE_OPENSSL_BACKEND "Use the openssl backend" OFF)
 	option (USE_SCHANNEL_BACKEND "Use the schannel backend (windows-only)" OFF)
 	option (USE_NSURL_BACKEND "Use the NSUrl backend (apple-only)" ON)
+
+  # Enabling ARC for apple/NSURLClient.mm
+  set_source_files_properties(apple/NSURLClient.mm PROPERTIES COMPILE_FLAGS "-fobjc-arc")
+
 	option (USE_ANDROID_BACKEND "Use the Android Java backend (Android-only)" OFF)
 	option (USE_WININET_BACKEND "Use the WinINet backend (windows-only)" OFF)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -117,8 +117,8 @@ elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
 	option (USE_SCHANNEL_BACKEND "Use the schannel backend (windows-only)" OFF)
 	option (USE_NSURL_BACKEND "Use the NSUrl backend (apple-only)" ON)
 
-  # Enabling ARC for apple/NSURLClient.mm
-  set_source_files_properties(apple/NSURLClient.mm PROPERTIES COMPILE_FLAGS "-fobjc-arc")
+	# Enabling ARC for apple/NSURLClient.mm
+	set_source_files_properties(apple/NSURLClient.mm PROPERTIES COMPILE_FLAGS "-fobjc-arc")
 
 	option (USE_ANDROID_BACKEND "Use the Android Java backend (Android-only)" OFF)
 	option (USE_WININET_BACKEND "Use the WinINet backend (windows-only)" OFF)


### PR DESCRIPTION
When trying to build this on an M1 Macbook pro, I encountered the error:

```
~/I/lua-https ❮❮❮ cmake --build build --target install
-- Configuring done (0.0s)
-- Generating done (0.0s)
-- Build files have been written to: /Users/sean/IdeaProjects/lua-https/build
[  9%] Building CXX object src/CMakeFiles/https-nsurl.dir/apple/NSURLClient.mm.o
/Users/sean/IdeaProjects/lua-https/src/apple/NSURLClient.mm:8:2: error: "ARC is off"
#error "ARC is off"
 ^
1 error generated.
make[2]: *** [src/CMakeFiles/https-nsurl.dir/apple/NSURLClient.mm.o] Error 1
make[1]: *** [src/CMakeFiles/https-nsurl.dir/all] Error 2
make: *** [all] Error 2
```

After adding ARC support:

```
~/I/lua-https ❮❮❮ cmake --build build --target install
-- Configuring done (0.0s)
-- Generating done (0.0s)
-- Build files have been written to: /Users/sean/IdeaProjects/lua-https/build
[  9%] Building CXX object src/CMakeFiles/https-nsurl.dir/apple/NSURLClient.mm.o
[ 18%] Linking CXX static library libhttps-nsurl.a
[ 18%] Built target https-nsurl
[ 27%] Building CXX object src/CMakeFiles/https-common.dir/common/HTTPS.cpp.o
[ 36%] Building CXX object src/CMakeFiles/https-common.dir/common/HTTPRequest.cpp.o
[ 45%] Building CXX object src/CMakeFiles/https-common.dir/common/HTTPSClient.cpp.o
[ 54%] Building CXX object src/CMakeFiles/https-common.dir/common/PlaintextConnection.cpp.o
[ 63%] Linking CXX static library libhttps-common.a
[ 63%] Built target https-common
[ 72%] Building CXX object src/CMakeFiles/https-unix-libraryloader.dir/generic/UnixLibraryLoader.cpp.o
[ 81%] Linking CXX static library libhttps-unix-libraryloader.a
[ 81%] Built target https-unix-libraryloader
[ 90%] Building CXX object src/CMakeFiles/https.dir/lua/main.cpp.o
[100%] Linking CXX shared module https.so
[100%] Built target https
```