### PR TITLE
fix: correct FTBFS for Android

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -19,7 +19,8 @@ LOCAL_SRC_FILES := \
 	src/common/HTTPRequest.cpp \
 	src/common/HTTPSClient.cpp \
 	src/common/PlaintextConnection.cpp \
-	src/android/AndroidClient.cpp
+	src/android/AndroidClient.cpp \
+	src/generic/UnixLibraryLoader.cpp
 
 LOCAL_SHARED_LIBRARIES := liblove
 


### PR DESCRIPTION
This pull request adds the missing `UnixLibraryLoader.cpp` to `Android.mk` so that it links successfully.

~~I found the pre-built `https.so` artifacts for other platforms useful, so I've added a GitHub workflow job to attach Android `https.so` artifacts during CI builds. As lua-https is bundled in LÖVE 12.0 by default, the workflow I've added builds against LÖVE 11.5a for Android.~~