### PR TITLE
Feature: Add Option for CMAKE_POSITION_INDEPENDENT_CODE

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,9 @@
 cmake_minimum_required (VERSION 3.13)
 
 ### Basic compilation settings
-set (CMAKE_POSITION_INDEPENDENT_CODE TRUE)
+if (NOT DEFINED CMAKE_POSITION_INDEPENDENT_CODE)
+  set(CMAKE_POSITION_INDEPENDENT_CODE TRUE CACHE BOOL "Build position independent code")
+endif()
 set (CMAKE_CXX_STANDARD 14)
 
 include_directories (

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,9 +1,11 @@
 cmake_minimum_required (VERSION 3.13)
 
 ### Basic compilation settings
-if (NOT DEFINED CMAKE_POSITION_INDEPENDENT_CODE)
-  set(CMAKE_POSITION_INDEPENDENT_CODE TRUE CACHE BOOL "Build position independent code")
-endif()
+option(HTTPS_USE_FPIC "Enable CMAKE_POSITION_INDEPENDENT_CODE" ON)
+if (HTTPS_USE_FPIC)
+	set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+endif ()
+
 set (CMAKE_CXX_STANDARD 14)
 
 include_directories (


### PR DESCRIPTION
Currently the project enforces a default of `CMAKE_POSITION_INDEPENDENT_CODE` to `ON`. Normally, this is not a problem, except in instances where `-fPIC` is not supported. In my case, compiling this for Wii U homebrew nets me compilation failure (see [this GitHub issue](https://github.com/devkitPro/wut/issues/116#issuecomment-1810385381). This pull request allows people to define `-DHTTPS_USE_FPIC` when invoking CMake or `set(HTTPS_USE_FPIC OFF CACHE BOOL "Disable PIC for lua-https" )` before adding the project to set whether it is to be used. Doing so has allowed for my Wii U homebrew to compile successfully.